### PR TITLE
Unhookd Gem v1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     unhookd (0.1.0)
-      httparty (~> 0.16.2)
+      httparty (>= 0.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,4 +36,4 @@ DEPENDENCIES
   unhookd!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/README.md
+++ b/README.md
@@ -19,36 +19,37 @@ Or install it yourself as:
     $ gem install unhookd
 
 ## Usage
-Unhookd can be configured and used in a Ruby Script for one off deploys.
+Unhookd can be configured and used in a Ruby Script for one off deploys. Here is an example:
 
 ```
-require 'unhookd'
+#!/usr/bin/env ruby
 
-# Configure unhookd
+require "unhookd"
+
+sha = ARGV[1]
+compare_url = ARGV[2]
+
 Unhookd.configure do |config|
-  config.unhookd_url = "your-url-to-your-unhookd-installation"
-  config.chart_name = "your-chart-repo/your-chart-name"
-  config.values_file_path = "path/to/file.yaml"
+  config.unhookd_url = "your-unhookd-url"
+  config.chart_name = "your-repo/your-chart"
 end
 
-# Call deploy with the correct args!
-Unhookd.deploy!("release-name", { "some_value" => "you'd like to set on your chart" })
-
-# Release name serves as both the namespace the app will be deployed in and the name of the Helm Release
-# The Chart Values hash are the values you would like to override in your values file e.g. the sha being deployed
+Unhookd.deploy!("release-name", { "your" => { "values" => "to-override}" } })
 ```
+
+By default, release-name serves as both the namespace the app will be deployed in and the name of the Helm release 
 
 Even better, pair this with a job in Circle Ci to enable continuous deploys to your Kubernetes cluster!
 
-## Slack Notification
-Unhookd also optionally supports notifying a Slack channel using the incoming webhooks feature of Slack. Configure your webhook url and set it and an optional message:
-
-```
-Unhookd.configure do |config|
-  config.slack_webhook_url = "your-slack-webhook-url"
-  config.slack_webhook_message = "Deployed with Unhookd!"
-end
-```
+## Configuration
+| Name                  | Required | Description                                                                                                               |
+|-----------------------|----------|---------------------------------------------------------------------------------------------------------------------------|
+| unhookd_url           | yes      | Url that Unhookd exposes in your cluster                                                                                  |
+| chart_name            | yes      | The charts repository and name for Unhookd to deploy e.g. repo/chart                                                      |
+| values_file_path      | no       | Path to a base values file where default values can be specified.                                                         |
+| namespace             | no       | A namespace to be installed in. If not specified, the value of the release name will be used.                             |
+| slack_webhook_url     | no       | A Slack Webhook URl to send a post-deploy notification to                                                                 |
+| slack_webhook_message | no       | A Slack Webhook Message to send with the post-deploy notification. Valid keys are: :header, :title, :title_link, :message |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Unhookd.configure do |config|
   config.unhookd_url = "your-url-to-your-unhookd-installation"
   config.chart_name = "your-chart-repo/your-chart-name"
   config.repo_name = "your-git-repository"
+  config.values_file_path = "path/to/file.yaml"
 end
 
 # Call deploy with the correct args!

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Unhookd.configure do |config|
 end
 
 # Call deploy with the correct args!
-Unhookd.deploy!("your-branch", { "some_value" => "you'd like to set on your chart" })
+Unhookd.deploy!("release-name", { "some_value" => "you'd like to set on your chart" })
+
+# Release name serves as both the namespace the app will be deployed in and the name of the Helm Release
+# The Chart Values hash are the values you would like to override in your values file e.g. the sha being deployed
 ```
 
 Even better, pair this with a job in Circle Ci to enable continuous deploys to your Kubernetes cluster!

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Unhookd.configure do |config|
 end
 
 # Call deploy with the correct args!
-Unhookd.deploy!("your-sha", "your-branch", { "some_value" => "you'd like to set on your chart" })
+Unhookd.deploy!("your-branch", { "some_value" => "you'd like to set on your chart" })
 ```
 
 Even better, pair this with a job in Circle Ci to enable continuous deploys to your Kubernetes cluster!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ require 'unhookd'
 Unhookd.configure do |config|
   config.unhookd_url = "your-url-to-your-unhookd-installation"
   config.chart_name = "your-chart-repo/your-chart-name"
-  config.repo_name = "your-git-repository"
   config.values_file_path = "path/to/file.yaml"
 end
 

--- a/lib/unhookd.rb
+++ b/lib/unhookd.rb
@@ -1,6 +1,7 @@
 require "unhookd/version"
 require "unhookd/configuration"
 require "unhookd/deployer"
+require "unhookd/notifiers/slack"
 
 module Unhookd
   class << self

--- a/lib/unhookd.rb
+++ b/lib/unhookd.rb
@@ -21,7 +21,7 @@ module Unhookd
     yield(configuration)
   end
 
-  def self.deploy!(branch, chart_values)
-    Unhookd::Deployer.new(branch, chart_values).deploy!
+  def self.deploy!(release_name, chart_values)
+    Unhookd::Deployer.new(release_name, chart_values).deploy!
   end
 end

--- a/lib/unhookd.rb
+++ b/lib/unhookd.rb
@@ -21,7 +21,7 @@ module Unhookd
     yield(configuration)
   end
 
-  def self.deploy!(sha, branch, chart_values)
-    Unhookd::Deployer.new(sha, branch, chart_values).deploy!
+  def self.deploy!(branch, chart_values)
+    Unhookd::Deployer.new(branch, chart_values).deploy!
   end
 end

--- a/lib/unhookd.rb
+++ b/lib/unhookd.rb
@@ -2,6 +2,7 @@ require "unhookd/version"
 require "unhookd/configuration"
 require "unhookd/deployer"
 require "unhookd/notifiers/slack"
+require "unhookd/base_values"
 
 module Unhookd
   class << self

--- a/lib/unhookd/base_values.rb
+++ b/lib/unhookd/base_values.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Unhookd
   class BaseValues
     def self.fetch

--- a/lib/unhookd/base_values.rb
+++ b/lib/unhookd/base_values.rb
@@ -1,0 +1,7 @@
+module Unhookd
+  class BaseValues
+    def self.fetch
+      Unhookd.configuration.values_file_path.nil? ?  {} : YAML.load_file(Unhookd.configuration.values_file_path)
+    end
+  end
+end

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -1,6 +1,6 @@
 module Unhookd
   class Configuration
-    attr_accessor :unhookd_url, :repo_name, :chart_name, :slack_webhook_url, :slack_webhook_message
+    attr_accessor :unhookd_url, :repo_name, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path
 
     def initialize
       @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes
@@ -8,6 +8,7 @@ module Unhookd
       @chart_name            = 'repo/chart'            # (required) The Charts repository and name for Unhookd to deploy
       @slack_webhook_url     = nil                     # (optional) A Slack Webhook URl to send a post-deploy notification to
       @slack_webhook_message = nil                     # (optional) A Slack Webhook Message to send with the post-deploy notification
+      @values_file_path      = nil                     # (optional) Path to a base values file where default values can be specified.
     end
   end
 end

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -6,7 +6,12 @@ module Unhookd
       @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes
       @chart_name            = 'repo/chart'            # (required) The Charts repository and name for Unhookd to deploy
       @slack_webhook_url     = nil                     # (optional) A Slack Webhook URl to send a post-deploy notification to
-      @slack_webhook_message = nil                     # (optional) A Slack Webhook Message to send with the post-deploy notification
+      @slack_webhook_message = {                       # (optional) A Slack Webhook Message to send with the post-deploy notification. Valid keys are: :header, :title, :title_link, :message
+        header: "Something was deployed!",
+        title: nil,
+        title_link: nil,
+        message: nil,
+      }
       @values_file_path      = nil                     # (optional) Path to a base values file where default values can be specified.
       @async                 = nil                     # (optional) Whether or not Unhookd should wait for the release to complete, before returning an http status
       @namespace             = nil                     # (optional) A namespace to be installed in. If not specified, the value of the release name will be used.

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -3,8 +3,11 @@ module Unhookd
     attr_accessor :unhookd_url, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path, :async, :namespace
 
     def initialize
-      @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes
-      @chart_name            = 'repo/chart'            # (required) The Charts repository and name for Unhookd to deploy
+      @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes in your cluster
+      @chart_name            = 'repo/chart'            # (required) The charts repository and name for Unhookd to deploy e.g. repo/chart
+      @values_file_path      = nil                     # (optional) Path to a base values file where default values can be specified.
+      @async                 = nil                     # (optional) Whether or not Unhookd should wait for the release to complete, before returning an http status
+      @namespace             = nil                     # (optional) A namespace to be installed in. If not specified, the value of the release name will be used.
       @slack_webhook_url     = nil                     # (optional) A Slack Webhook URl to send a post-deploy notification to
       @slack_webhook_message = {                       # (optional) A Slack Webhook Message to send with the post-deploy notification. Valid keys are: :header, :title, :title_link, :message
         header: "Something was deployed!",
@@ -12,9 +15,6 @@ module Unhookd
         title_link: nil,
         message: nil,
       }
-      @values_file_path      = nil                     # (optional) Path to a base values file where default values can be specified.
-      @async                 = nil                     # (optional) Whether or not Unhookd should wait for the release to complete, before returning an http status
-      @namespace             = nil                     # (optional) A namespace to be installed in. If not specified, the value of the release name will be used.
     end
   end
 end

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -1,6 +1,6 @@
 module Unhookd
   class Configuration
-    attr_accessor :unhookd_url, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path, :async
+    attr_accessor :unhookd_url, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path, :async, :namespace
 
     def initialize
       @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes
@@ -9,6 +9,7 @@ module Unhookd
       @slack_webhook_message = nil                     # (optional) A Slack Webhook Message to send with the post-deploy notification
       @values_file_path      = nil                     # (optional) Path to a base values file where default values can be specified.
       @async                 = nil                     # (optional) Whether or not Unhookd should wait for the release to complete, before returning an http status
+      @namespace             = nil                     # (optional) A namespace to be installed in. If not specified, the value of the release name will be used.
     end
   end
 end

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -1,10 +1,9 @@
 module Unhookd
   class Configuration
-    attr_accessor :unhookd_url, :repo_name, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path
+    attr_accessor :unhookd_url, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path
 
     def initialize
       @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes
-      @repo_name             = 'repo_name'             # (required) The Git repository name of the project
       @chart_name            = 'repo/chart'            # (required) The Charts repository and name for Unhookd to deploy
       @slack_webhook_url     = nil                     # (optional) A Slack Webhook URl to send a post-deploy notification to
       @slack_webhook_message = nil                     # (optional) A Slack Webhook Message to send with the post-deploy notification

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -1,6 +1,6 @@
 module Unhookd
   class Configuration
-    attr_accessor :unhookd_url, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path
+    attr_accessor :unhookd_url, :chart_name, :slack_webhook_url, :slack_webhook_message, :values_file_path, :async
 
     def initialize
       @unhookd_url           = 'http://localhost:8080' # (required) The url that Unhookd exposes
@@ -8,6 +8,7 @@ module Unhookd
       @slack_webhook_url     = nil                     # (optional) A Slack Webhook URl to send a post-deploy notification to
       @slack_webhook_message = nil                     # (optional) A Slack Webhook Message to send with the post-deploy notification
       @values_file_path      = nil                     # (optional) Path to a base values file where default values can be specified.
+      @async                 = nil                     # (optional) Whether or not Unhookd should wait for the release to complete, before returning an http status
     end
   end
 end

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -5,7 +5,7 @@ module Unhookd
     def initialize(sha, branch, chart_values)
       @branch = branch
       @sha = sha
-      @final_values = { "values" => chart_values }
+      @final_values = chart_values
       @config = Unhookd.configuration
     end
 

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -27,7 +27,8 @@ module Unhookd
       {
         "release" => @release_name,
         "chart" => Unhookd.configuration.chart_name,
-        "async" => Unhookd.configuration.async
+        "async" => Unhookd.configuration.async,
+        "namespace" => Unhookd.configuration.namespace,
       }.delete_if { |_key, value| value.nil? }
     end
 

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -2,9 +2,8 @@ require 'httparty'
 
 module Unhookd
   class Deployer
-    def initialize(sha, branch, chart_values)
+    def initialize(branch, chart_values)
       @branch = branch
-      @sha = sha
       @final_values = Unhookd::BaseValues.fetch.merge(chart_values)
       @config = Unhookd.configuration
     end

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -17,7 +17,7 @@ module Unhookd
         verify: false,
       )
 
-      notify_slack unless @config.slack_webhook_url.nil?
+      Unhookd::Notifiers::Slack.notify!(@branch) unless @config.slack_webhook_url.nil?
       post_deploy_message
     end
 
@@ -32,30 +32,6 @@ module Unhookd
           "chart" => @config.chart_name,
         }
       )
-    end
-
-    def notify_slack
-      HTTParty.post(
-        @config.slack_webhook_url,
-        body: slack_webhook_body,
-        headers: { "Content-Type" => "application/json" },
-        verify: false,
-      )
-    end
-
-    def slack_webhook_body
-      {
-        "attachments" => [
-          {
-            "fallback" => "Your branch was deployed!",
-            "color" => "#36a64f",
-            "pretext" => "The '#{@branch}' branch was deployed!",
-            "author_name" => "Unhookd",
-            "text" => @config.slack_webhook_message,
-            "ts" => Time.now.to_i
-          }
-        ]
-      }.to_json
     end
 
     def post_deploy_message

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -12,7 +12,7 @@ module Unhookd
     def deploy!
       HTTParty.post(
         @config.unhookd_url,
-        body: get_values.to_json,
+        body: @final_values.to_json,
         query: unhookd_query_params,
         headers: { "Content-Type" => "application/json" },
         verify: false,
@@ -23,17 +23,6 @@ module Unhookd
     end
 
     private
-
-    def get_values
-      @final_values.merge!(
-        {
-          "branch" => @branch,
-          "release" => @branch,
-          "repo" => @config.repo_name,
-          "chart" => @config.chart_name,
-        }
-      )
-    end
 
     def unhookd_query_params
       {

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -13,6 +13,7 @@ module Unhookd
       HTTParty.post(
         @config.unhookd_url,
         body: get_values.to_json,
+        query: unhookd_query_params,
         headers: { "Content-Type" => "application/json" },
         verify: false,
       )
@@ -32,6 +33,13 @@ module Unhookd
           "chart" => @config.chart_name,
         }
       )
+    end
+
+    def unhookd_query_params
+      {
+        "release" => @branch,
+        "chart" => Unhookd.configuration.chart_name,
+      }
     end
 
     def post_deploy_message

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -2,8 +2,8 @@ require 'httparty'
 
 module Unhookd
   class Deployer
-    def initialize(branch, chart_values)
-      @branch = branch
+    def initialize(release_name, chart_values)
+      @release_name = release_name
       @final_values = Unhookd::BaseValues.fetch.merge(chart_values)
       @config = Unhookd.configuration
     end
@@ -25,7 +25,7 @@ module Unhookd
 
     def unhookd_query_params
       {
-        "release" => @branch,
+        "release" => @release_name,
         "chart" => Unhookd.configuration.chart_name,
       }
     end

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -5,7 +5,7 @@ module Unhookd
     def initialize(sha, branch, chart_values)
       @branch = branch
       @sha = sha
-      @final_values = chart_values
+      @final_values = Unhookd::BaseValues.fetch.merge(chart_values)
       @config = Unhookd.configuration
     end
 

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -17,7 +17,7 @@ module Unhookd
         verify: false,
       )
 
-      Unhookd::Notifiers::Slack.notify!(@branch) unless @config.slack_webhook_url.nil?
+      Unhookd::Notifiers::Slack.notify! unless @config.slack_webhook_url.nil?
       post_deploy_message
     end
 

--- a/lib/unhookd/deployer.rb
+++ b/lib/unhookd/deployer.rb
@@ -27,7 +27,8 @@ module Unhookd
       {
         "release" => @release_name,
         "chart" => Unhookd.configuration.chart_name,
-      }
+        "async" => Unhookd.configuration.async
+      }.delete_if { |_key, value| value.nil? }
     end
 
     def post_deploy_message

--- a/lib/unhookd/notifiers/slack.rb
+++ b/lib/unhookd/notifiers/slack.rb
@@ -1,7 +1,7 @@
 module Unhookd
   module Notifiers
     class Slack
-      def self.notify!(branch)
+      def self.notify!
         @config = Unhookd.configuration
 
         slack_webhook_body = {
@@ -9,7 +9,7 @@ module Unhookd
             {
               "fallback" => "Your branch was deployed!",
               "color" => "#36a64f",
-              "pretext" => "The '#{branch}' branch was deployed!",
+              "pretext" => "Something was deployed!",
               "author_name" => "Unhookd",
               "text" => @config.slack_webhook_message,
               "ts" => Time.now.to_i

--- a/lib/unhookd/notifiers/slack.rb
+++ b/lib/unhookd/notifiers/slack.rb
@@ -11,6 +11,8 @@ module Unhookd
               "color" => "#36a64f",
               "pretext" => @config.slack_webhook_message[:header],
               "author_name" => "Unhookd",
+              "title" => @config.slack_webhook_message[:title],
+              "title_link" => @config.slack_webhook_message[:title_link],
               "text" => @config.slack_webhook_message[:text],
               "ts" => Time.now.to_i
             }

--- a/lib/unhookd/notifiers/slack.rb
+++ b/lib/unhookd/notifiers/slack.rb
@@ -1,0 +1,29 @@
+module Unhookd
+  module Notifiers
+    class Slack
+      def self.notify!(branch)
+        @config = Unhookd.configuration
+
+        slack_webhook_body = {
+          "attachments" => [
+            {
+              "fallback" => "Your branch was deployed!",
+              "color" => "#36a64f",
+              "pretext" => "The '#{branch}' branch was deployed!",
+              "author_name" => "Unhookd",
+              "text" => @config.slack_webhook_message,
+              "ts" => Time.now.to_i
+            }
+          ]
+        }.to_json
+
+        HTTParty.post(
+          @config.slack_webhook_url,
+          body: slack_webhook_body,
+          headers: { "Content-Type" => "application/json" },
+          verify: false,
+        )
+      end
+    end
+  end
+end

--- a/lib/unhookd/notifiers/slack.rb
+++ b/lib/unhookd/notifiers/slack.rb
@@ -9,9 +9,9 @@ module Unhookd
             {
               "fallback" => "Your branch was deployed!",
               "color" => "#36a64f",
-              "pretext" => "Something was deployed!",
+              "pretext" => @config.slack_webhook_message[:header],
               "author_name" => "Unhookd",
-              "text" => @config.slack_webhook_message,
+              "text" => @config.slack_webhook_message[:text],
               "ts" => Time.now.to_i
             }
           ]

--- a/spec/fixtures/sample-values.yaml
+++ b/spec/fixtures/sample-values.yaml
@@ -1,0 +1,2 @@
+value1: foo
+value2: bar

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.after(:each) do
+    Unhookd.reset
+  end
 end

--- a/spec/unhookd/base_values_spec.rb
+++ b/spec/unhookd/base_values_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+RSpec.describe Unhookd::BaseValues do
+  describe ".fetch" do
+    context "when the user has configured a values file path" do
+      let(:values_file_path) { "spec/fixtures/sample-values.yaml" }
+      let(:expected_values_file_hash) { YAML.load_file(values_file_path) }
+
+      before do
+        Unhookd.configure do |config|
+          config.values_file_path = values_file_path
+        end
+      end
+
+      after do
+        Unhookd.reset
+      end
+
+      it "returns that file loaded as a hash" do
+        expect(described_class.fetch).to eq(expected_values_file_hash)
+      end
+    end
+
+    context "when the user has not configured a values file path" do
+      it "returns an empty hash" do
+        expect(described_class.fetch).to eq({})
+      end
+    end
+  end
+end

--- a/spec/unhookd/base_values_spec.rb
+++ b/spec/unhookd/base_values_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe Unhookd::BaseValues do
         end
       end
 
-      after do
-        Unhookd.reset
-      end
-
       it "returns that file loaded as a hash" do
         expect(described_class.fetch).to eq(expected_values_file_hash)
       end

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Unhookd::Configuration do
       end
     end
 
-    describe "#repo_name" do
-      it "has a default value of 'repo_name'" do
-        expect(Unhookd::Configuration.new.repo_name).to eq("repo_name")
-      end
-    end
-
     describe "#slack_webhook_url" do
       it "has a default value of nil" do
         expect(Unhookd::Configuration.new.slack_webhook_url).to eq(nil)
@@ -53,14 +47,6 @@ RSpec.describe Unhookd::Configuration do
         config = Unhookd::Configuration.new
         config.chart_name = "somechart/name"
         expect(config.chart_name).to eq("somechart/name")
-      end
-    end
-
-    describe "#repo_name=" do
-      it "can set a value" do
-        config = Unhookd::Configuration.new
-        config.repo_name = "some_repo"
-        expect(config.repo_name).to eq("some_repo")
       end
     end
 

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Unhookd::Configuration do
         expect(Unhookd::Configuration.new.async).to eq(nil)
       end
     end
+
+    describe "#namespace" do
+      it "has a default value of nil" do
+        expect(Unhookd::Configuration.new.namespace).to eq(nil)
+      end
+    end
   end
 
   describe "setters" do
@@ -85,6 +91,14 @@ RSpec.describe Unhookd::Configuration do
         config = Unhookd::Configuration.new
         config.async = true
         expect(config.async).to eq(true)
+      end
+    end
+
+    describe "#namespace=" do
+      it "can set a value" do
+        config = Unhookd::Configuration.new
+        config.namespace = 'foo'
+        expect(config.namespace).to eq('foo')
       end
     end
   end

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Unhookd::Configuration do
         expect(Unhookd::Configuration.new.values_file_path).to eq(nil)
       end
     end
+
+    describe "#async" do
+      it "has a default value of nil" do
+        expect(Unhookd::Configuration.new.async).to eq(nil)
+      end
+    end
   end
 
   describe "setters" do
@@ -71,6 +77,14 @@ RSpec.describe Unhookd::Configuration do
         config = Unhookd::Configuration.new
         config.values_file_path = "foo/bar/path.yaml"
         expect(config.values_file_path).to eq("foo/bar/path.yaml")
+      end
+    end
+
+    describe "#async=" do
+      it "can set a value" do
+        config = Unhookd::Configuration.new
+        config.async = true
+        expect(config.async).to eq(true)
       end
     end
   end

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Unhookd::Configuration do
         expect(Unhookd::Configuration.new.slack_webhook_message).to eq(nil)
       end
     end
+
+    describe "#values_file_path" do
+      it "has a default value of nil" do
+        expect(Unhookd::Configuration.new.values_file_path).to eq(nil)
+      end
+    end
   end
 
   describe "setters" do
@@ -71,6 +77,14 @@ RSpec.describe Unhookd::Configuration do
         config = Unhookd::Configuration.new
         config.slack_webhook_message = "I deployed your branch!"
         expect(config.slack_webhook_message).to eq("I deployed your branch!")
+      end
+    end
+
+    describe "#values_file_path=" do
+      it "can set a value" do
+        config = Unhookd::Configuration.new
+        config.values_file_path = "foo/bar/path.yaml"
+        expect(config.values_file_path).to eq("foo/bar/path.yaml")
       end
     end
   end

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe Unhookd::Configuration do
 
     describe "#slack_webhook_message" do
       it "has a default value of nil" do
-        expect(Unhookd::Configuration.new.slack_webhook_message).to eq(nil)
+        expect(Unhookd::Configuration.new.slack_webhook_message).to eq({
+          header: "Something was deployed!",
+          title: nil,
+          title_link: nil,
+          message: nil,
+        })
       end
     end
 
@@ -73,8 +78,8 @@ RSpec.describe Unhookd::Configuration do
     describe "#slack_webhook_message=" do
       it "can set a value" do
         config = Unhookd::Configuration.new
-        config.slack_webhook_message = "I deployed your branch!"
-        expect(config.slack_webhook_message).to eq("I deployed your branch!")
+        config.slack_webhook_message = { header: "hey", title: nil, title_link: "foo", text: "bar"}
+        expect(config.slack_webhook_message).to eq({ header: "hey", title: nil, title_link: "foo", text: "bar"})
       end
     end
 

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Unhookd::Deployer do
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
 
     subject { described_class.new(sha, branch, chart_values) }
-    
+
     it "sends a request to the configured endpoint with the correct values" do
       expect(HTTParty)
         .to receive(:post)

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -69,5 +69,48 @@ RSpec.describe Unhookd::Deployer do
         end
       end
     end
+
+    describe "async" do
+      context "when async is set" do
+        let(:expected_unhookd_query) { {
+          "release" => release_name,
+          "chart" => Unhookd.configuration.chart_name,
+          "async" => Unhookd.configuration.async
+        }}
+
+        before do
+          Unhookd.configure do |config|
+            config.async = true
+          end
+        end
+
+        after do
+          Unhookd.reset
+        end
+
+        it "sends the async query parameter" do
+          expect(HTTParty)
+            .to receive(:post)
+              .with(expected_unhookd_url, body: expected_unhookd_body, query: expected_unhookd_query, headers: expected_unhookd_headers, verify: false)
+
+          subject.deploy!
+        end
+      end
+
+      context "when async is not set" do
+        before do
+          expect(Unhookd.configuration.async).to be_falsey
+          expect(expected_unhookd_query.keys).not_to include(:async)
+        end
+
+        it "does not send the async query parameter" do
+          expect(HTTParty)
+            .to receive(:post)
+              .with(expected_unhookd_url, body: expected_unhookd_body, query: expected_unhookd_query, headers: expected_unhookd_headers, verify: false)
+
+          subject.deploy!
+        end
+      end
+    end
   end
 end

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Unhookd::Deployer do
     }}
 
     let(:expected_unhookd_url) { Unhookd.configuration.unhookd_url}
-    let(:expected_unhookd_body) { { "values" => chart_values }.to_json }
+    let(:expected_unhookd_body) { chart_values.to_json }
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
 
     subject { described_class.new(sha, branch, chart_values) }

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Unhookd::Deployer do
         end
 
         it "tells the Slack Notifier to send a notification" do
-          allow(Unhookd::Notifiers::Slack).to receive(:notify!).with(branch)
+          allow(Unhookd::Notifiers::Slack).to receive(:notify!)
 
           subject.deploy!
         end

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Unhookd::Deployer do
         "chart" => Unhookd.configuration.chart_name,
       }
     end
+
+    let(:expected_unhookd_query) { {
+      "release" => branch,
+      "chart" => Unhookd.configuration.chart_name,
+    }}
+
     let(:expected_unhookd_url) { Unhookd.configuration.unhookd_url}
     let(:expected_unhookd_body) { { "values" => chart_values }.merge(default_values).to_json }
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
@@ -22,7 +28,7 @@ RSpec.describe Unhookd::Deployer do
     it "sends a request to the configured endpoint with the correct values" do
       expect(HTTParty)
         .to receive(:post)
-        .with(expected_unhookd_url, body: expected_unhookd_body, headers: expected_unhookd_headers, verify: false)
+        .with(expected_unhookd_url, body: expected_unhookd_body, query: expected_unhookd_query, headers: expected_unhookd_headers, verify: false)
 
       subject.deploy!
     end

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Unhookd::Deployer do
   describe "#deploy" do
-    let(:sha) { "123" }
     let(:branch) { "my-branch" }
     let(:values_file_path) { "spec/fixtures/sample-values.yaml" }
     let(:file_values) { YAML.load_file(values_file_path) }
@@ -17,7 +16,7 @@ RSpec.describe Unhookd::Deployer do
     let(:expected_unhookd_body) { file_values.merge(chart_values).to_json }
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
 
-    subject { described_class.new(sha, branch, chart_values) }
+    subject { described_class.new(branch, chart_values) }
 
     before do
       Unhookd.configure do |config|

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Unhookd::Deployer do
       end
     end
 
-    describe "async" do
+    describe "namespace" do
       context "when async is set" do
         let(:expected_unhookd_query) { {
           "release" => release_name,
@@ -92,6 +92,45 @@ RSpec.describe Unhookd::Deployer do
         end
 
         it "does not send the async query parameter" do
+          expect(HTTParty)
+            .to receive(:post)
+              .with(expected_unhookd_url, body: expected_unhookd_body, query: expected_unhookd_query, headers: expected_unhookd_headers, verify: false)
+
+          subject.deploy!
+        end
+      end
+    end
+
+    describe "namespace" do
+      context "when namespace is set" do
+        let(:expected_unhookd_query) { {
+          "release" => release_name,
+          "chart" => Unhookd.configuration.chart_name,
+          "namespace" => Unhookd.configuration.namespace
+        }}
+
+        before do
+          Unhookd.configure do |config|
+            config.namespace = 'foo'
+          end
+        end
+
+        it "sends the namespace query parameter" do
+          expect(HTTParty)
+            .to receive(:post)
+              .with(expected_unhookd_url, body: expected_unhookd_body, query: expected_unhookd_query, headers: expected_unhookd_headers, verify: false)
+
+          subject.deploy!
+        end
+      end
+
+      context "when namespace is not set" do
+        before do
+          expect(Unhookd.configuration.namespace).to be_falsey
+          expect(expected_unhookd_query.keys).not_to include(:namespace)
+        end
+
+        it "does not send the namespace query parameter" do
           expect(HTTParty)
             .to receive(:post)
               .with(expected_unhookd_url, body: expected_unhookd_body, query: expected_unhookd_query, headers: expected_unhookd_headers, verify: false)

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Unhookd::Deployer do
   describe "#deploy" do
     let(:sha) { "123" }
     let(:branch) { "my-branch" }
+    let(:values_file_path) { "spec/fixtures/sample-values.yaml" }
+    let(:file_values) { YAML.load_file(values_file_path) }
     let(:chart_values) { { "foo" => 'bar' } }
 
     let(:expected_unhookd_query) { {
@@ -12,10 +14,20 @@ RSpec.describe Unhookd::Deployer do
     }}
 
     let(:expected_unhookd_url) { Unhookd.configuration.unhookd_url}
-    let(:expected_unhookd_body) { chart_values.to_json }
+    let(:expected_unhookd_body) { file_values.merge(chart_values).to_json }
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
 
     subject { described_class.new(sha, branch, chart_values) }
+
+    before do
+      Unhookd.configure do |config|
+        config.values_file_path = values_file_path
+      end
+    end
+
+    after do
+      Unhookd.reset
+    end
 
     it "sends a request to the configured endpoint with the correct values" do
       expect(HTTParty)

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 RSpec.describe Unhookd::Deployer do
   describe "#deploy" do
-    let(:branch) { "my-branch" }
+    let(:release_name) { "my-release_name" }
     let(:values_file_path) { "spec/fixtures/sample-values.yaml" }
     let(:file_values) { YAML.load_file(values_file_path) }
     let(:chart_values) { { "foo" => 'bar' } }
 
     let(:expected_unhookd_query) { {
-      "release" => branch,
+      "release" => release_name,
       "chart" => Unhookd.configuration.chart_name,
     }}
 
@@ -16,7 +16,7 @@ RSpec.describe Unhookd::Deployer do
     let(:expected_unhookd_body) { file_values.merge(chart_values).to_json }
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
 
-    subject { described_class.new(branch, chart_values) }
+    subject { described_class.new(release_name, chart_values) }
 
     before do
       Unhookd.configure do |config|

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -5,14 +5,6 @@ RSpec.describe Unhookd::Deployer do
     let(:sha) { "123" }
     let(:branch) { "my-branch" }
     let(:chart_values) { { "foo" => 'bar' } }
-    let(:default_values) do
-      {
-        "branch" => branch,
-        "release" => branch,
-        "repo" => Unhookd.configuration.repo_name,
-        "chart" => Unhookd.configuration.chart_name,
-      }
-    end
 
     let(:expected_unhookd_query) { {
       "release" => branch,
@@ -20,7 +12,7 @@ RSpec.describe Unhookd::Deployer do
     }}
 
     let(:expected_unhookd_url) { Unhookd.configuration.unhookd_url}
-    let(:expected_unhookd_body) { { "values" => chart_values }.merge(default_values).to_json }
+    let(:expected_unhookd_body) { { "values" => chart_values }.to_json }
     let(:expected_unhookd_headers) { { "Content-Type" => "application/json" } }
 
     subject { described_class.new(sha, branch, chart_values) }

--- a/spec/unhookd/deployer_spec.rb
+++ b/spec/unhookd/deployer_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe Unhookd::Deployer do
       end
     end
 
-    after do
-      Unhookd.reset
-    end
-
     it "sends a request to the configured endpoint with the correct values" do
       expect(HTTParty)
         .to receive(:post)
@@ -48,10 +44,6 @@ RSpec.describe Unhookd::Deployer do
           Unhookd.configure do |config|
             config.slack_webhook_url = slack_webhook_url
           end
-        end
-
-        after do
-          Unhookd.reset
         end
 
         it "tells the Slack Notifier to send a notification" do
@@ -82,10 +74,6 @@ RSpec.describe Unhookd::Deployer do
           Unhookd.configure do |config|
             config.async = true
           end
-        end
-
-        after do
-          Unhookd.reset
         end
 
         it "sends the async query parameter" do

--- a/spec/unhookd/notifiers/slack_spec.rb
+++ b/spec/unhookd/notifiers/slack_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe Unhookd::Notifiers::Slack do
       end
     end
 
-    after do
-      Unhookd.reset
-    end
-
     it "sends a request to slack with the correct params" do
       expect(HTTParty)
         .to receive(:post)

--- a/spec/unhookd/notifiers/slack_spec.rb
+++ b/spec/unhookd/notifiers/slack_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Unhookd::Notifiers::Slack do
             "color" => "#36a64f",
             "pretext" => Unhookd.configuration.slack_webhook_message[:header],
             "author_name" => "Unhookd",
+            "title" => Unhookd.configuration.slack_webhook_message[:title],
+            "title_link" => Unhookd.configuration.slack_webhook_message[:title_link],
             "text" => Unhookd.configuration.slack_webhook_message[:text],
             "ts" => Time.now.to_i
           }
@@ -25,6 +27,12 @@ RSpec.describe Unhookd::Notifiers::Slack do
     before do
       Unhookd.configure do |config|
         config.slack_webhook_url = slack_webhook_url
+        config.slack_webhook_message = {
+          header: "Hi there!",
+          title: "this is a link",
+          title_link: "https://google.com",
+          text: "Something else!",
+        }
       end
     end
 

--- a/spec/unhookd/notifiers/slack_spec.rb
+++ b/spec/unhookd/notifiers/slack_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Unhookd::Notifiers::Slack do
           {
             "fallback" => "Your branch was deployed!",
             "color" => "#36a64f",
-            "pretext" => "Something was deployed!",
+            "pretext" => Unhookd.configuration.slack_webhook_message[:header],
             "author_name" => "Unhookd",
-            "text" => Unhookd.configuration.slack_webhook_message,
+            "text" => Unhookd.configuration.slack_webhook_message[:text],
             "ts" => Time.now.to_i
           }
         ]

--- a/spec/unhookd/notifiers/slack_spec.rb
+++ b/spec/unhookd/notifiers/slack_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Unhookd::Notifiers::Slack do
+  describe '.notify!' do
+    let(:branch) { "my-branch" }
+    let(:slack_webhook_url) { "http://my-slack-webhook-url.com" }
+    let(:expected_slack_url) { Unhookd.configuration.slack_webhook_url }
+    let(:expected_slack_body) do
+      {
+        "attachments" => [
+          {
+            "fallback" => "Your branch was deployed!",
+            "color" => "#36a64f",
+            "pretext" => "The '#{branch}' branch was deployed!",
+            "author_name" => "Unhookd",
+            "text" => Unhookd.configuration.slack_webhook_message,
+            "ts" => Time.now.to_i
+          }
+        ]
+      }.to_json
+    end
+
+    let(:expected_slack_headers) { { "Content-Type" => "application/json" } }
+
+    before do
+      Unhookd.configure do |config|
+        config.slack_webhook_url = slack_webhook_url
+      end
+    end
+
+    after do
+      Unhookd.reset
+    end
+
+    it "sends a request to slack with the correct params" do
+      expect(HTTParty)
+        .to receive(:post)
+        .with(expected_slack_url, body: expected_slack_body, headers: expected_slack_headers, verify: false)
+
+      described_class.notify!(branch)
+    end
+  end
+end

--- a/spec/unhookd/notifiers/slack_spec.rb
+++ b/spec/unhookd/notifiers/slack_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Unhookd::Notifiers::Slack do
           {
             "fallback" => "Your branch was deployed!",
             "color" => "#36a64f",
-            "pretext" => "The '#{branch}' branch was deployed!",
+            "pretext" => "Something was deployed!",
             "author_name" => "Unhookd",
             "text" => Unhookd.configuration.slack_webhook_message,
             "ts" => Time.now.to_i
@@ -37,7 +37,7 @@ RSpec.describe Unhookd::Notifiers::Slack do
         .to receive(:post)
         .with(expected_slack_url, body: expected_slack_body, headers: expected_slack_headers, verify: false)
 
-      described_class.notify!(branch)
+      described_class.notify!
     end
   end
 end

--- a/spec/unhookd_spec.rb
+++ b/spec/unhookd_spec.rb
@@ -40,16 +40,15 @@ RSpec.describe Unhookd do
   end
 
   describe ".deploy!" do
-    let(:sha) { '123' }
     let(:branch) { 'my-branch' }
     let(:chart_values) { { foo: 'bar' }}
-    let(:deployer_stub) { Unhookd::Deployer.new(sha, branch, chart_values) }
+    let(:deployer_stub) { Unhookd::Deployer.new(branch, chart_values) }
 
     it "initializes an Unhookd::Deployer with passed args and calls #deploy! on it" do
-      expect(Unhookd::Deployer).to receive(:new).with(sha, branch, chart_values).and_return(deployer_stub)
+      expect(Unhookd::Deployer).to receive(:new).with(branch, chart_values).and_return(deployer_stub)
       expect(deployer_stub).to receive(:deploy!)
 
-      Unhookd.deploy!(sha, branch, chart_values)
+      Unhookd.deploy!(branch, chart_values)
     end
   end
 end

--- a/spec/unhookd_spec.rb
+++ b/spec/unhookd_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe Unhookd do
 
       expect(config.unhookd_url).to eq('www.some-url-in-a-cluster.com')
     end
-
-    after :each do
-      Unhookd.reset
-    end
   end
 
   describe ".reset" do

--- a/spec/unhookd_spec.rb
+++ b/spec/unhookd_spec.rb
@@ -40,15 +40,15 @@ RSpec.describe Unhookd do
   end
 
   describe ".deploy!" do
-    let(:branch) { 'my-branch' }
+    let(:release_name) { 'my-release_name' }
     let(:chart_values) { { foo: 'bar' }}
-    let(:deployer_stub) { Unhookd::Deployer.new(branch, chart_values) }
+    let(:deployer_stub) { Unhookd::Deployer.new(release_name, chart_values) }
 
     it "initializes an Unhookd::Deployer with passed args and calls #deploy! on it" do
-      expect(Unhookd::Deployer).to receive(:new).with(branch, chart_values).and_return(deployer_stub)
+      expect(Unhookd::Deployer).to receive(:new).with(release_name, chart_values).and_return(deployer_stub)
       expect(deployer_stub).to receive(:deploy!)
 
-      Unhookd.deploy!(branch, chart_values)
+      Unhookd.deploy!(release_name, chart_values)
     end
   end
 end

--- a/unhookd.gemspec
+++ b/unhookd.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.16.2"
+  spec.add_dependency "httparty", ">= 0.10.0"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
This branch updates the gem to,

- Support the latest Unhookd API
- Be more permissive in its dependencies to allow it to be installed in more apps

An example of Unhookd being used can be found [here](https://github.com/mavenlink-solutions/konekti/pull/1207)

TODO
- [x] Support the `namespace` flag in Unhookd
- [x] Allow support for a more configurable slack message, at least on par with https://github.com/mavenlink-solutions/konekti/pull/1118/files#diff-037ac6ca2f7c3d4496f922096242987bR85