### PR TITLE
Increase timeout

### DIFF
--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -24,7 +24,7 @@ module Unhookd
         message: nil,
       }
       @logger                = nil # (optional) Logger object
-      @read_timeout          = 120 # (optional) Time client will wait for response from server
+      @read_timeout          = 600 # (optional) Time client will wait for response from server
     end
   end
 end

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Unhookd::Configuration do
 
     describe "#read_timeout" do
       it "has a default value of 120" do
-        expect(Unhookd::Configuration.new.read_timeout).to eq(120)
+        expect(Unhookd::Configuration.new.read_timeout).to eq(600)
       end
     end
   end


### PR DESCRIPTION
Increase timeout to match ingress rules and avoid audit log deployment failures

Signed-off-by: Armando Cerna <armando@mavenlink.com>