### PR TITLE
Reset timeout to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Even better, pair this with a job in Circle Ci to enable continuous deploys to y
 | namespace             | no       | A namespace to be installed in. If not specified, the value of the release name will be used.                             |
 | slack_webhook_url     | no       | A Slack Webhook URl to send a post-deploy notification to                                                                 |
 | slack_webhook_message | no       | A Slack Webhook Message to send with the post-deploy notification. Valid keys are: :header, :title, :title_link, :message |
+| read_timeout          | no       | Time client will wait for response from server                                                                            |
 
 ## Configuring Slack Notifications
 

--- a/lib/unhookd/configuration.rb
+++ b/lib/unhookd/configuration.rb
@@ -24,7 +24,7 @@ module Unhookd
         message: nil,
       }
       @logger                = nil # (optional) Logger object
-      @read_timeout          = 600 # (optional) Time client will wait for response from server
+      @read_timeout          = 120 # (optional) Time client will wait for response from server
     end
   end
 end

--- a/spec/unhookd/configuration_spec.rb
+++ b/spec/unhookd/configuration_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Unhookd::Configuration do
 
     describe "#read_timeout" do
       it "has a default value of 120" do
-        expect(Unhookd::Configuration.new.read_timeout).to eq(600)
+        expect(Unhookd::Configuration.new.read_timeout).to eq(120)
       end
     end
   end


### PR DESCRIPTION
We had increased timeout to 600 to fix audit log deployments. This config is overwritten in audit logs so we are resetting the value here (its default) to 120.